### PR TITLE
GEM-16216: Use secure temp directory for snapshot archive extraction

### DIFF
--- a/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/snapshot/SnapshotServiceFactoryBean.java
+++ b/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/snapshot/SnapshotServiceFactoryBean.java
@@ -16,8 +16,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -468,12 +469,8 @@ public class SnapshotServiceFactoryBean<K, V> extends AbstractFactoryBeanSupport
 			if (ArchiveFileFilter.INSTANCE.accept(file)) {
 				try {
 
-					File extractedArchiveDirectory =
-						new File(TEMPORARY_DIRECTORY, file.getName().replaceAll("\\.", "-"));
-
-					Assert.state(extractedArchiveDirectory.isDirectory() || extractedArchiveDirectory.mkdirs(),
-						String.format("Failed create directory (%1$s) in which to extract archive (%2$s)",
-							extractedArchiveDirectory, file));
+					String dirPrefix = file.getName().replaceAll("\\.", "-");
+					File extractedArchiveDirectory = Files.createTempDirectory(dirPrefix).toFile();
 
 					ZipFile zipFile = (ArchiveFileFilter.INSTANCE.isJarFile(file)
 						? new JarFile(file, false, JarFile.OPEN_READ)
@@ -484,15 +481,17 @@ public class SnapshotServiceFactoryBean<K, V> extends AbstractFactoryBeanSupport
 
 							DataInputStream entryInputStream = new DataInputStream(zipFile.getInputStream(entry));
 
-							DataOutputStream entryOutputStream = new DataOutputStream(new FileOutputStream(
-								new File(extractedArchiveDirectory, toSimpleFilename(entry.getName()))));
+							OutputStream entryOutputStream = Files.newOutputStream(
+								new File(extractedArchiveDirectory, toSimpleFilename(entry.getName())).toPath());
+
+							DataOutputStream dataEntryOutputStream = new DataOutputStream(entryOutputStream);
 
 							try {
-								FileCopyUtils.copy(entryInputStream, entryOutputStream);
+								FileCopyUtils.copy(entryInputStream, dataEntryOutputStream);
 							}
 							finally {
 								exceptionSuppressingClose(entryInputStream);
-								exceptionSuppressingClose(entryOutputStream);
+								exceptionSuppressingClose(dataEntryOutputStream);
 							}
 						}
 					}

--- a/spring-data-vmware-gemfire/src/test/java/org/springframework/data/gemfire/snapshot/SnapshotServiceFactoryBeanIntegrationTests.java
+++ b/spring-data-vmware-gemfire/src/test/java/org/springframework/data/gemfire/snapshot/SnapshotServiceFactoryBeanIntegrationTests.java
@@ -8,9 +8,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.data.gemfire.snapshot.SnapshotServiceFactoryBean.SnapshotServiceAdapterSupport;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -69,11 +72,21 @@ public class SnapshotServiceFactoryBeanIntegrationTests {
 			assertThat(toFilenames(actualSnapshots).containsAll(Arrays.asList(
 				"accounts.snapshot", "address.snapshot", "people.snapshot"))).isTrue();
 
-			cacheSnapshotZipDirectory = new File(System.getProperty("java.io.tmpdir"),
-				cacheSnapshotZip.getName().replaceAll("\\.", "-"));
+			cacheSnapshotZipDirectory = actualSnapshots[0].getParentFile();
+			String expectedPrefix = cacheSnapshotZip.getName().replaceAll("\\.", "-");
 
 			assertThat(cacheSnapshotZipDirectory.isDirectory()).isTrue();
+			assertThat(cacheSnapshotZipDirectory.getName()).startsWith(expectedPrefix);
 			assertThat(cacheSnapshotZipDirectory.listFiles(FileSystemUtils.FileOnlyFilter.INSTANCE)).isEqualTo(actualSnapshots);
+
+			if (!System.getProperty("os.name").toLowerCase().contains("win")) {
+				Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(cacheSnapshotZipDirectory.toPath());
+				assertThat(permissions).containsExactlyInAnyOrder(
+					PosixFilePermission.OWNER_READ,
+					PosixFilePermission.OWNER_WRITE,
+					PosixFilePermission.OWNER_EXECUTE
+				);
+			}
 		}
 		finally {
 			if (cacheSnapshotZipDirectory != null && cacheSnapshotZipDirectory.isDirectory()) {


### PR DESCRIPTION
Replace insecure mkdirs() with Files.createTempDirectory() to ensure the temporary directory used for archive extraction has owner-only permissions (700), preventing other system users from reading sensitive snapshot data. Also use Files.newOutputStream() for extracted files.

ai-assisted=yes