### PR TITLE
GEM-17646: deprecate conserve-sockets to match GemFire.

### DIFF
--- a/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/GemFireProperties.java
+++ b/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/GemFireProperties.java
@@ -34,6 +34,7 @@ public enum GemFireProperties {
 	BIND_ADDRESS(ConfigurationProperties.BIND_ADDRESS, String.class),
 	CACHE_XML_FILE(ConfigurationProperties.CACHE_XML_FILE, String.class),
 	CONFLATE_EVENTS(ConfigurationProperties.CONFLATE_EVENTS, String.class, "server"),
+	@Deprecated
 	CONSERVE_SOCKETS(ConfigurationProperties.CONSERVE_SOCKETS, Boolean.class, true),
 	DELTA_PROPAGATION(ConfigurationProperties.DELTA_PROPAGATION, Boolean.class, true),
 	DEPLOY_WORKING_DIRECTORY(ConfigurationProperties.DEPLOY_WORKING_DIR, File.class, new File(".")),

--- a/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/config/annotation/EnableGemFireProperties.java
+++ b/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/config/annotation/EnableGemFireProperties.java
@@ -103,7 +103,9 @@ public @interface EnableGemFireProperties {
 	 * for GemFire members that participate in a WAN deployment.
 	 *
 	 * Defaults to {@literal true}.
+	 * @deprecated The {@literal conserve-sockets} property has been deprecated in GemFire.
 	 */
+	@Deprecated
 	boolean conserveSockets() default GemFirePropertiesConfiguration.DEFAULT_CONSERVE_SOCKETS;
 
 	/**

--- a/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/config/annotation/GemFirePropertiesConfiguration.java
+++ b/spring-data-vmware-gemfire/src/main/java/org/springframework/data/gemfire/config/annotation/GemFirePropertiesConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.data.gemfire.util.PropertiesBuilder;
  */
 public class GemFirePropertiesConfiguration extends EmbeddedServiceConfigurationSupport {
 
+	@Deprecated
 	public static final boolean DEFAULT_CONSERVE_SOCKETS = true;
 	public static final boolean DEFAULT_DELTA_PROPAGATION = true;
 	public static final boolean DEFAULT_DISABLE_TCP = false;
@@ -93,9 +94,6 @@ public class GemFirePropertiesConfiguration extends EmbeddedServiceConfiguration
 
 		gemfireProperties.setPropertyIfNotDefault("conflate-events",
 			annotationAttributes.get("conflateEvents"), DEFAULT_CONFLATE_EVENTS);
-
-		gemfireProperties.setPropertyIfNotDefault("conserve-sockets",
-			annotationAttributes.get("conserveSockets"), DEFAULT_CONSERVE_SOCKETS);
 
 		gemfireProperties.setPropertyIfNotDefault("delta-propagation",
 			annotationAttributes.get("deltaPropagation"), DEFAULT_DELTA_PROPAGATION);

--- a/spring-data-vmware-gemfire/src/test/java/org/springframework/data/gemfire/GemFirePropertiesUnitTests.java
+++ b/spring-data-vmware-gemfire/src/test/java/org/springframework/data/gemfire/GemFirePropertiesUnitTests.java
@@ -73,6 +73,7 @@ public class GemFirePropertiesUnitTests {
             "security-client-authenticator", // replaced by SecurityManager
             "security-client-dhalgo", // use SSL instead
 				    "security-peer-authenticator", // replaced by SecurityManager
+				    "conserve-sockets", // deprecated in GemFire 10.3
 				    "distributed-transactions", // being removed
             "statistic-sampling-enabled",
             "security-shiro-init"

--- a/spring-test-vmware-gemfire/src/test/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupportIntegrationTests.java
+++ b/spring-test-vmware-gemfire/src/test/java/org/springframework/data/gemfire/tests/mock/GemFireMockObjectsSupportIntegrationTests.java
@@ -102,7 +102,6 @@ public class GemFireMockObjectsSupportIntegrationTests extends IntegrationTestsS
 				GemFireMockObjectsSupport.spyOn(new ClientCacheFactory(gemfireProperties));
 
 			mockCacheFactory.set("groups", "qa,test,testers");
-			mockCacheFactory.set("conserve-sockets", "true");
 
 			ClientCache mockCache = mockCacheFactory.create();
 
@@ -112,13 +111,12 @@ public class GemFireMockObjectsSupportIntegrationTests extends IntegrationTestsS
 			Properties actualGemFireProperties = mockCache.getDistributedSystem().getProperties();
 
 			assertThat(actualGemFireProperties).isNotNull();
-			assertThat(actualGemFireProperties).hasSize(6);
+			assertThat(actualGemFireProperties).hasSize(5);
 			assertThat(actualGemFireProperties.getProperty("name")).isEqualTo("TestStoresGemFirePropertiesSuccessfully");
 			assertThat(actualGemFireProperties.getProperty("log-level")).isEqualTo("config");
 			assertThat(actualGemFireProperties.getProperty("locators")).isEqualTo("skullbox[12345]");
 			assertThat(actualGemFireProperties.getProperty("jmx-manager-port")).isEqualTo("1199");
 			assertThat(actualGemFireProperties.getProperty("groups")).isEqualTo("qa,test,testers");
-			assertThat(actualGemFireProperties.getProperty("conserve-sockets")).isEqualTo("true");
 		}
 		finally {
 			System.clearProperty("gemfire.name");


### PR DESCRIPTION
conserve-sockets was deprecated by GEM-16477.