### PR TITLE
GEM-18834: Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ generated-pipeline.yml
 *.crf
 *.dat
 /build-tools/convention-plugins/.gradle
+*.salive

--- a/build-tools/convention-plugins/build.gradle.kts
+++ b/build-tools/convention-plugins/build.gradle.kts
@@ -29,6 +29,10 @@ repositories {
         }
       }
     }
+
+  if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+    mavenCentral()
+  }
 }
 
 dependencies {

--- a/build-tools/convention-plugins/settings.gradle.kts
+++ b/build-tools/convention-plugins/settings.gradle.kts
@@ -25,6 +25,10 @@ pluginManagement {
           }
         }
       }
+
+    if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+      gradlePluginPortal()
+    }
   }
 }
 

--- a/build-tools/publishing/build.gradle.kts
+++ b/build-tools/publishing/build.gradle.kts
@@ -28,6 +28,10 @@ repositories {
         }
       }
     }
+
+  if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+    mavenCentral()
+  }
 }
 
 dependencies {

--- a/build-tools/publishing/settings.gradle.kts
+++ b/build-tools/publishing/settings.gradle.kts
@@ -24,6 +24,10 @@ pluginManagement {
           }
         }
       }
+
+    if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+      gradlePluginPortal()
+    }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,10 @@ buildscript {
           }
         }
       }
+
+    if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+      mavenCentral()
+    }
   }
 }
 
@@ -66,6 +70,9 @@ allprojects {
           }
         }
       }
+    if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+      mavenCentral()
+    }
   }
 }
 
@@ -78,10 +85,6 @@ versionCatalogUpdate {
   }
   keep {
     keepUnusedVersions = true
-    // keep all libraries that aren't used in the project
-    keepUnusedLibraries = true
-    // keep all plugins that aren't used in the project
-    keepUnusedPlugins = true
   }
 
   versionCatalogs {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,11 @@ version=1.0.0-build.9999
 description = 'Spring Data for VMware GemFire'
 
 minimumGradleVersion = 9.5
+baseGemFireVersion=10.3
+baseSpringVersion=4.0
 gemfireVersion= [10.3,10.4)
-spring-framework.version=[7.0,7.1)
-spring-data-bom.version=[2025.1,2025.2)
+spring-framework.version=7.0.7
+spring-data-bom.version=2025.1.5
 spring.gemfire.enable.private.repositories=true
 
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,77 +1,90 @@
 [versions]
-annotationApiVersion = "2.1.1"
-antlrVersion = "2.7.6"
-aspectJVersion = "1.9.22.1"
-assertJVersion = "3.26.3"
-awaitilityVersion = "4.2.2"
+annotationApiVersion = "3.0.0"
+antlrVersion = "2.7.7"
+aspectJVersion = "1.9.25.1"
+assertJVersion = "3.27.7"
+awaitilityVersion = "4.3.0"
 cacheApiVersion = "1.1.1"
-cdiApiVersion = "4.0.1"
-derbyVersion = "10.9.1.0"
+cdiApiVersion = "4.1.0"
+derbyVersion = "10.17.1.0"
 gemFireTestContainersVersion = "3.0.0"
-googleCloudStorageVersion = "2.45.0"
+gemfireVersion = "10.3.0"
+googleCloudStorageVersion = "2.68.0"
 interceptorApiVersion = "1.2.2"
-jUnitJupiterVersion = "5.11.4"
-jUnitPlatformVersion = "1.11.4"
+jUnitJupiterVersion = "6.1.0"
+jUnitPlatformVersion = "6.1.0"
 jUnitVersion = "4.13.2"
-jacksonVersion = "2.18.2"
-log4JVersion = "2.24.2"
-logbackVersion = "1.5.18"
-lombokPluginVersion = "8.11"
-lombokVersion = "1.18.38"
-mockitoVersion = "5.14.2"
+jacksonDatabindVersion = "2.21.3"
+jacksonVersion = "2.21"
+log4JVersion = "2.26.0"
+logbackVersion = "1.5.32"
+lombokPluginVersion = "9.5.0"
+lombokVersion = "1.18.46"
+mockitoVersion = "5.23.0"
 multithreadedTCVersion = "1.01"
-openWebBeansVersion = "2.0.28"
-snappyVersion = "0.4"
-springBootVersion = "4.0.0"
+openWebBeansVersion = "4.1.0"
+snappyVersion = "0.5"
+springBootVersion = "4.0.6.1"
 springShellVersion = "1.2.0.RELEASE"
-springShiroVersion = "2.0.6"
-versionCatalogUpdateVersion = "0.8.5"
-versionsVersion = "0.50.0"
+springShiroVersion = "2.2.0"
+versionCatalogUpdateVersion = "1.1.0"
+versionsVersion = "0.54.0"
 
 [libraries]
-gemfire-core = { module = "com.vmware.gemfire:gemfire-core", version.ref = "gemfireVersion" }
-gemfire-logging = { module = "com.vmware.gemfire:gemfire-logging", version.ref = "gemfireVersion" }
-gemfire-cq = { module = "com.vmware.gemfire:gemfire-cq", version.ref = "gemfireVersion" }
-gemfire-wan = { module = "com.vmware.gemfire:gemfire-wan", version.ref = "gemfireVersion" }
-gemfire-gfsh = { module = "com.vmware.gemfire:gemfire-gfsh", version.ref = "gemfireVersion" }
-gemfire-tcp-server = { module = "com.vmware.gemfire:gemfire-tcp-server", version.ref = "gemfireVersion" }
-gemfire-deployment-chained-classloader = { module = "com.vmware.gemfire:gemfire-deployment-chained-classloader", version.ref = "gemfireVersion" }
-cache-api = { module = "javax.cache:cache-api", version.ref = "cacheApiVersion" }
-spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "springBootVersion" }
-spring-shiro = { module = "org.apache.shiro:shiro-spring", version.ref = "springShiroVersion" }
-spring-shell = { module = "org.springframework.shell:spring-shell", version.ref = "springShellVersion" }
-aspectJ = { module = "org.aspectj:aspectjweaver", version.ref = "aspectJVersion" }
-jackson-annotation = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jacksonVersion" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonVersion" }
-antlr = { module = "antlr:antlr", version.ref = "antlrVersion" }
-cdi-api = { module = "jakarta.enterprise:jakarta.enterprise.cdi-api", version.ref = "cdiApiVersion" }
-interceptor-api = { module = "javax.interceptor:javax.interceptor-api", version.ref = "interceptorApiVersion" }
-logback = { module = "ch.qos.logback:logback-classic", version.ref = "logbackVersion" }
-log4J = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4JVersion" }
 annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "annotationApiVersion" }
+antlr = { module = "antlr:antlr", version.ref = "antlrVersion" }
+aspectJ = { module = "org.aspectj:aspectjweaver", version.ref = "aspectJVersion" }
+assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJVersion" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
+cache-api = { module = "javax.cache:cache-api", version.ref = "cacheApiVersion" }
+cdi-api = { module = "jakarta.enterprise:jakarta.enterprise.cdi-api", version.ref = "cdiApiVersion" }
 derby = { module = "org.apache.derby:derbyLocale_zh_TW", version.ref = "derbyVersion" }
-openwebbeans-se = { module = "org.apache.openwebbeans:openwebbeans-se", version.ref = "openWebBeansVersion" }
-openwebbeans-spi = { module = "org.apache.openwebbeans:openwebbeans-spi", version.ref = "openWebBeansVersion" }
-openwebbeans-impl = { module = "org.apache.openwebbeans:openwebbeans-impl", version.ref = "openWebBeansVersion" }
-snappy = { module = "org.iq80.snappy:snappy", version.ref = "snappyVersion" }
-multithreadedtc = { module = "edu.umd.cs.mtc:multithreadedtc", version.ref = "multithreadedTCVersion" }
+gemfire-core = { module = "com.vmware.gemfire:gemfire-core", version.ref = "gemfireVersion" }
+gemfire-cq = { module = "com.vmware.gemfire:gemfire-cq", version.ref = "gemfireVersion" }
+gemfire-deployment-chained-classloader = { module = "com.vmware.gemfire:gemfire-deployment-chained-classloader", version.ref = "gemfireVersion" }
+gemfire-gfsh = { module = "com.vmware.gemfire:gemfire-gfsh", version.ref = "gemfireVersion" }
+gemfire-logging = { module = "com.vmware.gemfire:gemfire-logging", version.ref = "gemfireVersion" }
+gemfire-tcp-server = { module = "com.vmware.gemfire:gemfire-tcp-server", version.ref = "gemfireVersion" }
+gemfire-testcontainers = { module = "dev.gemfire:gemfire-testcontainers", version.ref = "gemFireTestContainersVersion" }
+gemfire-wan = { module = "com.vmware.gemfire:gemfire-wan", version.ref = "gemfireVersion" }
+google-cloud-storage = { module = "com.google.cloud:google-cloud-storage", version.ref = "googleCloudStorageVersion" }
+interceptor-api = { module = "javax.interceptor:javax.interceptor-api", version.ref = "interceptorApiVersion" }
+jackson-annotation = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jacksonVersion" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabindVersion" }
+junit = { module = "junit:junit", version.ref = "jUnitVersion" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jUnitJupiterVersion" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jUnitJupiterVersion" }
-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "jUnitJupiterVersion" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "jUnitPlatformVersion" }
-junit = { module = "junit:junit", version.ref = "jUnitVersion" }
-assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJVersion" }
-mockito = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "jUnitJupiterVersion" }
+log4J = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4JVersion" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logbackVersion" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombokVersion" }
-awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
-gemfire-testcontainers = { module = "dev.gemfire:gemfire-testcontainers", version.ref = "gemFireTestContainersVersion" }
-google-cloud-storage = { module = "com.google.cloud:google-cloud-storage", version.ref = "googleCloudStorageVersion" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
+multithreadedtc = { module = "edu.umd.cs.mtc:multithreadedtc", version.ref = "multithreadedTCVersion" }
+openwebbeans-impl = { module = "org.apache.openwebbeans:openwebbeans-impl", version.ref = "openWebBeansVersion" }
+openwebbeans-se = { module = "org.apache.openwebbeans:openwebbeans-se", version.ref = "openWebBeansVersion" }
+openwebbeans-spi = { module = "org.apache.openwebbeans:openwebbeans-spi", version.ref = "openWebBeansVersion" }
+snappy = { module = "org.iq80.snappy:snappy", version.ref = "snappyVersion" }
+spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "springBootVersion" }
+spring-shell = { module = "org.springframework.shell:spring-shell", version.ref = "springShellVersion" }
+spring-shiro = { module = "org.apache.shiro:shiro-spring", version.ref = "springShiroVersion" }
 
 [plugins]
-versions = { id = "com.github.ben-manes.versions", version.ref = "versionsVersion" }
-version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdateVersion" }
 lombok = { id = "io.freefair.lombok", version.ref = "lombokPluginVersion" }
+version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdateVersion" }
+versions = { id = "com.github.ben-manes.versions", version.ref = "versionsVersion" }
 
 [bundles]
-gemfire = ["gemfire-core", "gemfire-logging", "gemfire-cq", "gemfire-gfsh", "gemfire-wan", "gemfire-tcp-server", "gemfire-deployment-chained-classloader"]
-jackson = ["jackson-annotation", "jackson-databind"]
+gemfire = [
+    "gemfire-core",
+    "gemfire-cq",
+    "gemfire-deployment-chained-classloader",
+    "gemfire-gfsh",
+    "gemfire-logging",
+    "gemfire-tcp-server",
+    "gemfire-wan",
+]
+jackson = [
+    "jackson-annotation",
+    "jackson-databind",
+]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,10 @@ pluginManagement {
           }
         }
       }
+
+    if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+      gradlePluginPortal()
+    }
   }
 }
 

--- a/spring-data-vmware-gemfire/build.gradle.kts
+++ b/spring-data-vmware-gemfire/build.gradle.kts
@@ -34,6 +34,10 @@ buildscript {
           }
         }
       }
+
+    if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+      mavenCentral()
+    }
   }
   dependencies {
     classpath(libs.google.cloud.storage)
@@ -83,8 +87,11 @@ tasks.withType<JavaCompile>().configureEach {
   options.compilerArgs.add("-parameters")
 }
 
+val baseGemFireVersion: String by project
+val baseSpringVersion: String by project
+
 publishingDetails {
-  artifactName.set("spring-data-4.0-gemfire-10.3")
+  artifactName.set("spring-data-${baseSpringVersion}-gemfire-${baseGemFireVersion}")
   longName.set("Spring Data VMware GemFire")
   description.set("Spring Data For VMware GemFire")
   test.set(false)
@@ -119,9 +126,9 @@ dependencies {
   testImplementation(libs.log4J)
   testImplementation(libs.annotation.api)
   testImplementation(libs.derby)
-  testImplementation(variantOf(libs.openwebbeans.se) { classifier("jakarta") })
-  testImplementation(variantOf(libs.openwebbeans.spi) { classifier("jakarta") })
-  testImplementation(variantOf(libs.openwebbeans.impl) { classifier("jakarta") })
+  testImplementation(libs.openwebbeans.se)
+  testImplementation(libs.openwebbeans.spi)
+  testImplementation(libs.openwebbeans.impl)
   testImplementation(libs.assertJ)
   testImplementation(libs.snappy)
   testImplementation(libs.spring.shell) {

--- a/spring-test-vmware-gemfire/build.gradle.kts
+++ b/spring-test-vmware-gemfire/build.gradle.kts
@@ -25,6 +25,10 @@ buildscript {
                     }
                 }
             }
+
+        if (providers.gradleProperty("useMavenCentral").getOrElse("false").toBoolean()) {
+            mavenCentral()
+        }
     }
 }
 
@@ -48,10 +52,13 @@ tasks.named<Javadoc>("javadoc") {
     isFailOnError = false
 }
 
+val baseGemFireVersion: String by project
+val baseSpringVersion: String by project
+
 publishingDetails {
-    artifactName.set("spring-data-4.0-gemfire-test-framework-10.3")
-    longName.set("Spring Test Framework for VMware GemFire 10.3 and Spring Data 4.0")
-    description.set("Spring Test Framework for VMware GemFire 10.3 and Spring Data 4.0")
+    artifactName.set("spring-data-${baseSpringVersion}-gemfire-test-framework-${baseGemFireVersion}")
+    longName.set("Spring Test Framework for VMware GemFire ${baseGemFireVersion} and Spring Data ${baseSpringVersion}")
+    description.set("Spring Test Framework for VMware GemFire ${baseGemFireVersion} and Spring Data ${baseSpringVersion}")
     test.set(true)
 }
 


### PR DESCRIPTION
- jakarta.annotation-api: 2.1.1 -> 3.0.0
- antlr: 2.7.6 -> 2.7.7
- aspectjweaver: 1.9.22.1 -> 1.9.25.1
- assertj-core: 3.26.3 -> 3.27.7
- awaitility: 4.2.2 -> 4.3.0
- jakarta.enterprise.cdi-api: 4.0.1 -> 4.1.0
- derby: 10.9.1.0 -> 10.17.1.0
- google-cloud-storage: 2.45.0 -> 2.68.0
- junit-jupiter: 5.11.4 -> 6.1.0
- junit-platform: 1.11.4 -> 6.1.0
- jackson-annotations: 2.18.2 -> 2.21
- jackson-databind: 2.18.2 -> 2.21.3
- log4j: 2.24.2 -> 2.26.0
- logback: 1.5.18 -> 1.5.32
- lombok: 1.18.38 -> 1.18.46
- mockito: 5.14.2 -> 5.23.0
- openwebbeans: 2.0.28 -> 4.1.0
- snappy: 0.4 -> 0.5
- spring-boot: 4.0.0 -> 4.0.6.1
- shiro-spring: 2.0.6 -> 2.2.0
- version-catalog-update (plugin): 0.8.5 -> 1.1.0
- versions (plugin): 0.50.0 -> 0.54.0

ai-assisted=yes